### PR TITLE
Book length limit 

### DIFF
--- a/db/migrate/20200211134024_add_book_title_size_limit.rb
+++ b/db/migrate/20200211134024_add_book_title_size_limit.rb
@@ -1,13 +1,17 @@
 class AddBookTitleSizeLimit < ActiveRecord::Migration[5.1]
-  def change
+  def up
     truncate_book_titles
-    change_column :books, :title, :text, :limit => 25
+    change_column :books, :title, :string, :limit => 25
+  end
+
+  def down
+    change_column :books, :title, :string, :limit => nil
   end
   
   def truncate_book_titles
-    Book.all.each do |b|
-      b.title = b.title.truncate(25)
-      b.save!
+    Book.all.each do |book|
+      book.title = book.title.truncate(25)
+      book.save!
     end
   end
 end

--- a/db/migrate/20200211134024_add_book_title_size_limit.rb
+++ b/db/migrate/20200211134024_add_book_title_size_limit.rb
@@ -1,0 +1,13 @@
+class AddBookTitleSizeLimit < ActiveRecord::Migration[5.1]
+  def change
+    truncate_book_titles
+    change_column :books, :title, :text, :limit => 25
+  end
+  
+  def truncate_book_titles
+    Book.all.each do |b|
+      b.title = b.title.truncate(25)
+      b.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191230131819) do
+ActiveRecord::Schema.define(version: 20200211134024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20191230131819) do
     t.string "genre", null: false
     t.string "author", null: false
     t.string "image", null: false
-    t.string "title", null: false
+    t.text "title", null: false
     t.string "editor", null: false
     t.string "year", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200211134024) do
+ActiveRecord::Schema.define(version: 20191230131819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20200211134024) do
     t.string "genre", null: false
     t.string "author", null: false
     t.string "image", null: false
-    t.text "title", null: false
+    t.string "title", null: false
     t.string "editor", null: false
     t.string "year", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191230131819) do
+ActiveRecord::Schema.define(version: 20200211134024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20191230131819) do
     t.string "genre", null: false
     t.string "author", null: false
     t.string "image", null: false
-    t.string "title", null: false
+    t.string "title", limit: 25, null: false
     t.string "editor", null: false
     t.string "year", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/book_factory.rb
+++ b/spec/factories/book_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     genre { Faker::Book.genre }
     author { Faker::Book.author }
     image { Faker::Internet.url(host: 'wolox.com.ar', path: '/image.jpg') }
-    title { Faker::Book.title }
+    title { Faker::Book.title.truncate(25) }
     editor { Faker::Book.publisher }
     year { Faker::Number.between(from: 0, to: 2019) }
   end


### PR DESCRIPTION
### Summary

- Generated a migration to limit the length of the book titles to 25.
- For the existing books, it truncated their titles and added "..." at the end.

### Trello card

https://trello.com/c/vOR570sA/43-migraciones-opcional